### PR TITLE
Removed "material" property of tetrahedron, that property belongs to …

### DIFF
--- a/4DRayTracer/Tetrahedron.cpp
+++ b/4DRayTracer/Tetrahedron.cpp
@@ -2,12 +2,11 @@
 #include "V4.h"
 #include "util.h"
 
-Tetrahedron::Tetrahedron(V4 a, V4 b, V4 c, V4 d, Material material) {
+Tetrahedron::Tetrahedron(V4 a, V4 b, V4 c, V4 d) {
 	this->abcd[0] = a;
 	this->abcd[1] = b;
 	this->abcd[2] = c;
 	this->abcd[3] = d;
-	this->material = material;
 }
 
 V4 Tetrahedron::getIntersection(V4 o, V4 dir, float *time) {

--- a/4DRayTracer/Tetrahedron.h
+++ b/4DRayTracer/Tetrahedron.h
@@ -3,12 +3,11 @@
 #include "V4.h"
 #include "Shape.h"
 
-class Tetrahedron : Shape {
+class Tetrahedron : public Shape {
 private:
 	V4 abcd[4];
-	Material material;
 public:
-	Tetrahedron(V4 a, V4 b, V4 c, V4 d, Material material);
+	Tetrahedron(V4 a, V4 b, V4 c, V4 d);
 	V4 getIntersection(V4 o, V4 dir, float* time);
 	V4 getNormal();
 	V4 getNormal(V4 p);


### PR DESCRIPTION
…Shape, and also has been changed slightly

Now each shape holds a pointer to a material (allowing for multiple objects to share the same material easily), and for now that is applied manually rather than in any of the constructors.

A shape with no assigned material will render as black by default